### PR TITLE
Remove audio resampling and add timing context support

### DIFF
--- a/neon_iris/web_client.py
+++ b/neon_iris/web_client.py
@@ -118,45 +118,6 @@ class GradIOClient(NeonAIClient):
         LOG.info(f"Updated profile for: {session_id}")
         return session_id
 
-    def send_audio(self, audio_file: str, lang: str = "en-us",
-                   username: Optional[str] = None,
-                   user_profiles: Optional[list] = None,
-                   context: Optional[dict] = None):
-        """
-        @param audio_file: path to wav audio file to send to speech module
-        @param lang: language code associated with request
-        @param username: username associated with request
-        @param user_profiles: user profiles expecting a response
-        """
-        # TODO: Audio conversion is really slow here. check ovos-stt-http-server
-        audio_file = self.convert_audio(audio_file)
-        self._send_audio(audio_file, lang, username, user_profiles, context)
-
-    def convert_audio(self, audio_file: str, target_sr=16000, target_channels=1,
-                      dtype='int16') -> str:
-        """
-        @param audio_file: path to audio file to convert for speech model
-        @returns: path to converted audio file
-        """
-        # Load the audio file
-        y, sr = librosa.load(audio_file, sr=None, mono=False)  # Load without changing sample rate or channels
-
-        # If the file has more than one channel, mix it down to one channel
-        if y.ndim > 1 and target_channels == 1:
-            y = librosa.to_mono(y)
-
-        # Resample the audio to the target sample rate
-        y_resampled = librosa.resample(y, orig_sr=sr, target_sr=target_sr)
-
-        # Ensure the audio array is in the correct format (int16 for 2-byte samples)
-        y_resampled = (y_resampled * (2 ** (8 * 2 - 1))).astype(dtype)
-
-        output_path = join(self._audio_path, f"{time()}.wav")
-        # Save the audio file with the new sample rate and sample width
-        sf.write(output_path, y_resampled, target_sr, format='WAV', subtype='PCM_16')
-        LOG.info(f"Converted audio file to {output_path}")
-        return output_path
-
     def on_user_input(self, utterance: str, *args, **kwargs) -> str:
         """
         Callback to handle textual user input

--- a/neon_iris/web_client.py
+++ b/neon_iris/web_client.py
@@ -148,7 +148,9 @@ class GradIOClient(NeonAIClient):
                             context={"gradio": {"session": gradio_id},
                                      "timing": {"wait_in_queue": in_queue,
                                                 "gradio_sent": time()}})
-        self._await_response.wait(30)
+        if not self._await_response.wait(30):
+            LOG.error("No response received after 30s")
+            self._await_response.set()
         self._response = self._response or "ERROR"
         LOG.info(f"Got response={self._response}")
         return self._response


### PR DESCRIPTION
# Description
Sends wav recordings directly to neon-speech without processing
Validated against updated deployment at mq.neonaialpha.com (port 25672)
Adds `client_sent` timing context and support for client-side context
Adds debug logging of timing for troubleshooting responses

# Issues
Closes #28

# Other Notes
https://github.com/NeonGeckoCom/neon_speech/pull/180