### PR TITLE
Get Language Support from Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ iris:
   webui_input_placeholder: "Chat with Neon"
 ```
 
+### Language Support
+For Neon Core deployments that support language support queries via MQ, `languages`
+may be removed and `enable_lang_api: True` added to configuration. This will use
+the reported STT/TTS supported languages in place of any `iris` configuration.
+
 ## Interfacing with a Diana installation
 The `iris` CLI includes utilities for interacting with a `Diana` backend.
 

--- a/docker_overlay/etc/neon/neon.yaml
+++ b/docker_overlay/etc/neon/neon.yaml
@@ -15,16 +15,7 @@ iris:
   server_address: "0.0.0.0"
   server_port: 7860
   default_lang: en-us
-  languages:
-    - en-us
-    - fr-fr
-    - es-es
-    - de-de
-    - it-it
-    - uk-ua
-    - nl-nl
-    - pt-pt
-    - ca-es
+  enable_lang_api: True
 
 location:
   city:

--- a/neon_iris/cli.py
+++ b/neon_iris/cli.py
@@ -140,6 +140,14 @@ def start_gradio():
         click.echo("Unable to connect to MQ server")
 
 
+@neon_iris_cli.command(help="Query Neon Core for supported languages")
+def get_languages():
+    from neon_iris.util import query_neon
+    _print_config()
+    resp = query_neon("neon.languages.get", {})
+    click.echo(pformat(resp))
+
+
 @neon_iris_cli.command(help="Transcribe an audio file")
 @click.option('--lang', '-l', default='en-us',
               help="language of input audio")

--- a/neon_iris/web_client.py
+++ b/neon_iris/web_client.py
@@ -220,14 +220,17 @@ class GradIOClient(NeonAIClient):
                 with gradio.Column():
                     lang = self.get_lang(client_session.value)
                     stt_lang = gradio.Radio(label="Input Language",
-                                            choices=self.supported_languages,
+                                            choices=self._languages.get("stt")
+                                            or self.supported_languages,
                                             value=lang)
                     tts_lang = gradio.Radio(label="Response Language",
-                                            choices=self.supported_languages,
+                                            choices=self._languages.get("tts")
+                                            or self.supported_languages,
                                             value=lang)
                     tts_lang_2 = gradio.Radio(label="Second Response Language",
                                               choices=[None] +
-                                                      self.supported_languages,
+                                              (self._languages.get("tts") or
+                                               self.supported_languages),
                                               value=None)
                 with gradio.Column():
                     time_format = gradio.Radio(label="Time Format",

--- a/neon_iris/web_client.py
+++ b/neon_iris/web_client.py
@@ -218,7 +218,7 @@ class GradIOClient(NeonAIClient):
             # Define settings UI
             with gradio.Row():
                 with gradio.Column():
-                    lang = self.get_lang(client_session.value)
+                    lang = self.get_lang(client_session.value).split('-')[0]
                     stt_lang = gradio.Radio(label="Input Language",
                                             choices=self._languages.get("stt")
                                             or self.supported_languages,


### PR DESCRIPTION
# Description
Adds option to get supported input/response languages from a connected Core

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Needs https://github.com/NeonGeckoCom/neon-messagebus-mq-connector/pull/50