### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,12 +11,12 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -28,7 +28,7 @@ jobs:
         run: |
           pytest tests/test_client.py --doctest-modules --junitxml=tests/client-test-results.xml
       - name: Upload client test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: client-test-results
-          path: tests/client-test-results.xml
+          path: tests/client-test-results-${{ matrix.python-version }}.xml


### PR DESCRIPTION
# Description
Update actions versions to latest
Update Python tests to remove deprecated 3.7 and add 3.11

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
This should also trigger a new alpha container build with updated dependencies to help troubleshoot configuration issues noted by @mikejgray 