### PR TITLE
fix: require numpy<2 for websat

### DIFF
--- a/requirements/web_sat.txt
+++ b/requirements/web_sat.txt
@@ -6,3 +6,4 @@ openwakeword~=0.5.1
 tflite~=2.10.0
 onnxruntime~=1.16.3
 jinja2~=3.1.2
+numpy<2

--- a/requirements/web_sat.txt
+++ b/requirements/web_sat.txt
@@ -6,4 +6,4 @@ openwakeword~=0.5.1
 tflite~=2.10.0
 onnxruntime~=1.16.3
 jinja2~=3.1.2
-numpy<2
+numpy~=1.0


### PR DESCRIPTION
# Description
There is a model in use that was compiled with Numpy 1.x and cannot load with 2.x. Per the error message, pinning below 2.x solves the issue. I was able to test this successfully on a Hub.
