### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -6,5 +6,3 @@ on:
 jobs:
   license_tests:
     uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
-    with:
-      packages-exclude: '^(precise-runner|fann2|tqdm|bs4|ovos-phal-plugin|ovos-skill|neon-core|nvidia|neon-phal-plugin|bitstruct|audioread).*'

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,6 +2,6 @@ click~=8.0
 click-default-group~=1.2
 neon-utils[sentry]~=1.12
 pyyaml>=5.4,<7.0.0
-neon-mq-connector~=0.8,>=0.8.1a3
+neon-mq-connector~=0.9
 ovos-bus-client~=0.0
-ovos-config~=0.1,<0.2.0
+ovos-config~=0.1


### PR DESCRIPTION
# Description
Update ovos-config to allow newer 0.x versions
Update neon-mq-dependency to stable version

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
#65 Added ovos-config with this artificial upper limit restriction, but there is no apparent reason for this