### PR TITLE
Refactor BCP-47 Language codes to ISO 639-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ MQ:
       user: neon_api_utils
       password: Klatchat2021
 iris:
-  default_lang: en-us
+  default_lang: en
   languages:
-    - en-us
-    - uk-ua
+    - en
+    - uk
   webui_chatbot_label: "Neon AI"
   webui_mic_label: "Speak with Neon"
   webui_input_placeholder: "Chat with Neon"

--- a/docker_overlay/opt/neon/neon.yaml
+++ b/docker_overlay/opt/neon/neon.yaml
@@ -15,7 +15,7 @@ iris:
   webui_ws_url: ws://localhost:8000/ws # Override, as this needs to be reachable by the browser
   server_address: "0.0.0.0"
   server_port: 7860
-  default_lang: en-us
+  default_lang: en
   enable_lang_api: True
 
 location:

--- a/neon_iris/client.py
+++ b/neon_iris/client.py
@@ -265,32 +265,36 @@ class NeonAIClient:
         self._languages = message.data
         if not all((x in self._languages for x in ("stt", "tts"))):
             LOG.warning(f"Language support incomplete response: {self._languages}")
+        self._languages['stt'] = [l.split('-')[0] 
+                                  for l in self._languages.get('stt', [])]
+        self._languages['tts'] = [l.split('-')[0] 
+                                  for l in self._languages.get('tts', [])]
         self._languages['stt'].sort()
         self._languages['tts'].sort()
         self._language_init.set()
 
-    def send_utterance(self, utterance: str, lang: str = "en-us",
+    def send_utterance(self, utterance: str, lang: str = "en",
                        username: Optional[str] = None,
                        user_profiles: Optional[list] = None,
                        context: Optional[dict] = None):
         """
         Optionally override this to queue text inputs or do any pre-parsing
         :param utterance: utterance to submit to skills module
-        :param lang: language code associated with request
+        :param lang: ISO 639-1 language code associated with request
         :param username: username associated with request
         :param user_profiles: user profiles expecting a response
         :param context: Optional dict context to add to emitted message
         """
         self._send_utterance(utterance, lang, username, user_profiles, context)
 
-    def send_audio(self, audio_file: str, lang: str = "en-us",
+    def send_audio(self, audio_file: str, lang: str = "en",
                    username: Optional[str] = None,
                    user_profiles: Optional[list] = None,
                    context: Optional[dict] = None):
         """
         Optionally override this to queue audio inputs or do any pre-parsing
         :param audio_file: path to audio file to send to speech module
-        :param lang: language code associated with request
+        :param lang: ISO 639-1 language code associated with request
         :param username: username associated with request
         :param user_profiles: user profiles expecting a response
         :param context: Optional dict context to add to emitted message
@@ -474,12 +478,12 @@ class CLIClient(NeonAIClient):
     def clear_media(self, message: Message):
         pass
 
-    def send_utterance(self, utterance: str, lang: str = "en-us",
+    def send_utterance(self, utterance: str, lang: str = "en",
                        _=None, __=None):
         """
         Queue a string request for skills processing
         :param utterance: User utterance to submit
-        :param lang: language of utterance
+        :param lang: ISO 639-1 language of utterance
         """
         self._response_event.clear()
         self._request_queue.put((utterance, lang))
@@ -488,12 +492,12 @@ class CLIClient(NeonAIClient):
         while not self._request_queue.empty():
             self._response_event.wait(30)
 
-    def send_audio(self, audio_file: str, lang: str = "en-us",
+    def send_audio(self, audio_file: str, lang: str = "en",
                    _=None, __=None):
         """
         Send an audio file for skills processing
         :param audio_file: Audio File to submit for STT processing
-        :param lang: language of audio
+        :param lang: ISO 639-1 language of audio
         """
         self._response_event.clear()
         self._send_audio(audio_file, lang, self.username, self.user_profiles)

--- a/neon_iris/web_client.py
+++ b/neon_iris/web_client.py
@@ -58,21 +58,29 @@ class GradIOClient(NeonAIClient):
         self._audio_path = join(xdg_data_home(), "iris", "stt")
         if not isdir(self._audio_path):
             makedirs(self._audio_path)
-        self.default_lang = lang or self.config.get('default_lang')
+        self.default_lang = (lang or 
+                             self.config.get('default_lang')).split('-')[0]
         self.chat_ui = gradio.Blocks()
 
-    def get_lang(self, session_id: str):
+    def get_lang(self, session_id: str) -> str:
+        """
+        Get the ISO 639-1 language code for the specified session
+        @param session_id: Gradio session ID
+        @returns: ISO 639-1 language code
+        """
         if session_id and session_id in self._profiles:
-            return self._profiles[session_id]['speech']['stt_language']
-        return self.user_config['speech']['stt_language'] or self.default_lang
+            return self._profiles[session_id]['speech']['stt_language'].split('-')[0]
+        return (self.user_config['speech']['stt_language'] or 
+                self.default_lang).split('-')[0]
 
     @property
     def supported_languages(self) -> List[str]:
         """
         Get a list of supported languages from configuration
-        @returns: list of BCP-47 language codes
+        @returns: list of ISO 639-1 language codes
         """
-        return self.config.get('languages') or [self.default_lang]
+        return [lang.split('-')[0] for lang in 
+                self.config.get('languages') or [self.default_lang]]
 
     def _start_session(self):
         sid = uuid4().hex
@@ -228,7 +236,7 @@ class GradIOClient(NeonAIClient):
                 check_alerts = gradio.Button("Check for Alerts")
             with gradio.Row():
                 with gradio.Column():
-                    lang = self.get_lang(client_session.value).split('-')[0]
+                    lang = self.get_lang(client_session.value)
                     stt_lang = gradio.Radio(label="Input Language",
                                             choices=self._languages.get("stt")
                                             or self.supported_languages,

--- a/neon_iris/web_sat_client.py
+++ b/neon_iris/web_sat_client.py
@@ -72,7 +72,8 @@ class WebSatNeonClient(NeonAIClient):
         )  # TODO: Clear periodically, or have persistent storage
         if not isdir(self._audio_path):
             makedirs(self._audio_path)
-        self.default_lang = lang or self.config.get("default_lang", "")
+        self.default_lang = (lang or 
+                             self.config.get("default_lang", "")).split('-')[0]
         LOG.name = "iris"
         LOG.init(self.config.get("logs"))
         # OpenWW
@@ -86,10 +87,11 @@ class WebSatNeonClient(NeonAIClient):
         self.build_routes()
 
     def get_lang(self, session_id: str):
-        """Get the language for a session."""
+        """Get the ISO 693-1 language code for a session."""
         if session_id and session_id in self._profiles:
             return self._profiles[session_id]["speech"]["stt_language"]
-        return self.user_config["speech"]["stt_language"] or self.default_lang
+        return (self.user_config["speech"]["stt_language"] or 
+                self.default_lang).split('-')[0]
 
     def handle_api_response(self, message: Message):
         """
@@ -122,7 +124,7 @@ class WebSatNeonClient(NeonAIClient):
     def send_audio( # pylint: disable=arguments-renamed
         self,
         audio_b64_string: str,
-        lang: str = "en-us",
+        lang: str = "en",
         username: Optional[str] = None,
         user_profiles: Optional[list] = None,
         context: Optional[dict] = None,
@@ -151,9 +153,9 @@ class WebSatNeonClient(NeonAIClient):
     def supported_languages(self) -> Sequence[str]:
         """
         Get a list of supported languages from configuration
-        @returns: list of BCP-47 language codes
+        @returns: list of ISO 639-1 language codes
         """
-        languages = self.config.get("languages")
+        languages = [l.split('-')[0] for l in self.config.get("languages")]
         if languages is None:
             return [self.default_lang]
         if not isinstance(languages, list):
@@ -266,7 +268,7 @@ class WebSatNeonClient(NeonAIClient):
                 LOG.info(f"Sending utterance: {utterance} with lang: {lang}")
                 self.send_utterance(
                     utterance,
-                    lang or "en-us",
+                    lang or "en",
                     username=session_id,
                     user_profiles=[self._profiles[session_id]],
                     context={
@@ -278,7 +280,7 @@ class WebSatNeonClient(NeonAIClient):
                 LOG.info(f"Sending audio with length of {len(audio_input)} with lang: {lang}")
                 self.send_audio(
                     audio_input,
-                    lang or "en-us",
+                    lang or "en",
                     username=session_id,
                     user_profiles=[self._profiles[session_id]],
                     context={


### PR DESCRIPTION
# Description
Update to normalize language codes to ISO 639-1 everywhere (i.e. `en`)
Update documentation and Docker default config to use ISO 639-1 instead of BCP-47

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Most APIs specify BCP-47, but in practice many STT/TTS services only specify ISO 639-1. Since we can normalize to ISO 639-1 and not the other way around, this makes Iris more compatible with other services