### PR TITLE
Implement models from `neon-data-models`

### DIFF
--- a/neon_iris/client.py
+++ b/neon_iris/client.py
@@ -142,18 +142,19 @@ class NeonAIClient:
         with _stopwatch:
             response = b64_to_dict(body)
         LOG.debug(f"Message deserialized in {_stopwatch.time}s")
+        # TODO: This is an MQ response object
         message = Message(response.get('msg_type'), response.get('data'),
                           response.get('context'))
 
         # Get timing data and log
         message.context.setdefault("timing", {})
-        resp_time = message.context['timing'].get('response_sent', recv_time)
+        resp_time = message.context['timing'].get('response_sent') or recv_time
         if recv_time != resp_time:
             transit_time = recv_time - resp_time
             message.context['timing']['client_from_core'] = transit_time
             LOG.debug(f"Response MQ transit time={transit_time}")
-        handling_time = recv_time - message.context['timing'].get('client_sent',
-                                                                  recv_time)
+        handling_time = recv_time - (message.context['timing'].get(
+            'client_sent') or recv_time)
         LOG.info(f"{message.msg_type} handled in {handling_time}")
         LOG.debug(f"{pformat(message.context['timing'])}")
         if message.msg_type == "klat.response":

--- a/neon_iris/voice_client.py
+++ b/neon_iris/voice_client.py
@@ -43,6 +43,7 @@ from ovos_utils.xdg_utils import xdg_data_home
 from ovos_utils.sound import play_wav
 from ovos_bus_client.message import Message
 from neon_utils.file_utils import decode_base64_string_to_file
+from neon_data_models.models.api.messagebus import NeonTtsResponse
 from neon_iris.client import NeonAIClient
 
 
@@ -111,14 +112,17 @@ class NeonVoiceClient(NeonAIClient):
         self.bus.emit(Message(msg_type, payload, context))
 
     def handle_klat_response(self, message: Message):
-        responses = message.data.get('responses')
+        response = NeonTtsResponse(msg_type=message.msg_type,
+                                   data=message.data,
+                                   context=message.context)
+        responses = response.data.responses
         for lang, data in responses.items():
-            text = data.get('sentence')
+            text = data.sentence
             LOG.info(text)
             file_basename = f"{hash(text)}.wav"
-            genders = data.get('genders', [])
+            genders = data.genders
             for gender in genders:
-                audio_data = data["audio"].get(gender)
+                audio_data = data.audio.get(gender)
                 audio_file = join(self._tts_audio_path, lang, gender,
                                   file_basename)
                 try:

--- a/neon_iris/web_client.py
+++ b/neon_iris/web_client.py
@@ -284,11 +284,11 @@ class GradIOClient(NeonAIClient):
         response = NeonTtsResponse(msg_type=message.msg_type,
                                    data=message.data,
                                    context=message.context)
-        LOG.debug(f"gradio context={message.context.get('gradio')}")
+        LOG.debug(f"gradio context={response.context.gradio}")
         resp_data = response.data.responses
         files = []
         sentences = []
-        session = message.context['gradio']['session']
+        session = response.context.gradio.session
         LOG.debug(f"Got response {resp_data}")
         for lang, response in resp_data.items():
             LOG.debug(f"Response for {lang}: {response}")

--- a/neon_iris/web_client.py
+++ b/neon_iris/web_client.py
@@ -37,9 +37,9 @@ from ovos_bus_client import Message
 from ovos_config import Configuration
 from ovos_utils import LOG
 from ovos_utils.json_helper import merge_dict
-
 from neon_utils.file_utils import decode_base64_string_to_file
 from ovos_utils.xdg_utils import xdg_data_home
+from neon_data_models.models.api.messagebus import NeonTtsResponse
 
 from neon_iris.client import NeonAIClient
 
@@ -281,17 +281,24 @@ class GradIOClient(NeonAIClient):
         audio in all requested languages.
         @param message: Neon response message
         """
-        LOG.debug(f"gradio context={message.context['gradio']}")
-        resp_data = message.data["responses"]
+        response = NeonTtsResponse(msg_type=message.msg_type,
+                                   data=message.data,
+                                   context=message.context)
+        LOG.debug(f"gradio context={message.context.get('gradio')}")
+        resp_data = response.data.responses
         files = []
         sentences = []
         session = message.context['gradio']['session']
+        LOG.debug(f"Got response {resp_data}")
         for lang, response in resp_data.items():
-            sentences.append(response.get("sentence"))
-            if response.get("audio"):
-                for gender, data in response["audio"].items():
+            LOG.debug(f"Response for {lang}: {response}")
+            sentences.append(response.sentence)
+            if response.audio:
+                for gender, data in response.audio.items():
+                    audio_path = getattr(response, gender)
+                    LOG.debug(f"Got audio file: {audio_path}")
                     filepath = "/".join([self.audio_cache_dir] +
-                                        response[gender].split('/')[-4:])
+                                        audio_path.split('/')[-4:])
                     # TODO: This only plays the most recent, so it doesn't
                     #  support multiple languages or multi-utterance responses
                     self._current_tts[session] = filepath

--- a/neon_iris/web_sat_client.py
+++ b/neon_iris/web_sat_client.py
@@ -44,6 +44,7 @@ from ovos_bus_client import Message
 from ovos_config import Configuration
 from ovos_utils import LOG
 from ovos_utils.xdg_utils import xdg_data_home
+from neon_data_models.models.api.messagebus import NeonTtsResponse
 
 from neon_iris.client import NeonAIClient
 from neon_iris.models.web_sat import UserInput, UserInputResponse
@@ -107,14 +108,17 @@ class WebSatNeonClient(NeonAIClient):
         audio in all requested languages.
         @param message: Neon response message
         """
-        LOG.debug(f"gradio context={message.context['gradio']}")
-        resp_data = message.data["responses"]
+        response = NeonTtsResponse(msg_type=message.msg_type,
+                                   data=message.data,
+                                   context=message.context)
+        LOG.debug(f"gradio context={response.context.gradio}")
+        resp_data = response.data.responses
         sentences = []
-        session = message.context["gradio"]["session"]
+        session = response.context.gradio.session
         for _, response in resp_data.items():  # lang, response
-            sentences.append(response.get("sentence"))
-            if response.get("audio"):
-                for _, data in response["audio"].items():
+            sentences.append(response.sentence)
+            if response.audio:
+                for _, data in response.audio.items():
                     self._current_tts[session] = data
         self._response = "\n".join(sentences)
         self._await_response.set()

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,3 +5,4 @@ pyyaml>=5.4,<7.0.0
 neon-mq-connector~=0.9
 ovos-bus-client~=0.0
 ovos-config~=0.1
+neon-data-models~=0.0,>=0.0.2a2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,4 +5,4 @@ pyyaml>=5.4,<7.0.0
 neon-mq-connector~=0.9
 ovos-bus-client~=0.0
 ovos-config~=0.1
-neon-data-models~=0.0,>=0.0.2a2
+neon-data-models~=0.0,>=0.0.2a3


### PR DESCRIPTION
# Description
Implement Pydantic models for response validation
Update `timing` context references to resolve exceptions related to default `None` values

# Issues
- Needed to support https://github.com/NeonGeckoCom/neon-messagebus-mq-connector/pull/61 as this fixes some unsafe timing context references

# Other Notes
Currently deployed to [alpha](https://iris.neonaialpha.com/)